### PR TITLE
Fix deprecated usage of async_forward_entry_setup

### DIFF
--- a/custom_components/energy_id/__init__.py
+++ b/custom_components/energy_id/__init__.py
@@ -14,7 +14,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Forward the setup to the sensor platform.
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, 'sensor')
+        hass.config_entries.async_forward_entry_setups(entry, ['sensor'])
     )
 
     async_setup_services(hass)


### PR DESCRIPTION
Fix for https://github.com/tijsverkoyen/HomeAssistant-EnergyID/issues/19